### PR TITLE
chore: replace soon to be deprecated method

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "prepack": "tsc"
   },
   "dependencies": {
+    "estree-walker": "^3.0.3",
     "magic-string": "^0.30.3"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import MagicString from "magic-string";
-import { parse, walk } from "svelte/compiler";
+import { parse } from 'svelte/compiler';
+import { walk } from 'estree-walker';
 import type { Element } from "svelte/types/compiler/interfaces";
 import type { SveltePreprocessor } from "svelte/types/compiler/preprocess";
 


### PR DESCRIPTION
just like https://github.com/micantoine/svelte-preprocess-cssmodules/pull/100 , the `walk` function in `svelte/compiler` will be deprecated and it doesn't work on svelte5