### PR TITLE
chore(package): add `exports` to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,12 @@
   "author": "Eric Liu (https://github.com/metonym)",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js"
+    }
+  },
   "scripts": {
     "test": "bun test",
     "build": "bun --bun tsc"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "exports": {
     ".": {
       "import": "./dist/index.js",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
When I use it with svelte5, I got the following error,
```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in /node_modules/.pnpm/svelte-preprocess-directives@0.1.1/node_modules/estree-walker/package.json
    at exportsNotFound (node:internal/modules/esm/resolve:304:10)
    at packageExportsResolve (node:internal/modules/esm/resolve:594:13)
    at resolveExports (node:internal/modules/cjs/loader:592:36)
    at Module._findPath (node:internal/modules/cjs/loader:669:31)
    at Module._resolveFilename (node:internal/modules/cjs/loader:1131:27)
    at Module._load (node:internal/modules/cjs/loader:986:27)
    at Module.require (node:internal/modules/cjs/loader:1233:19)
    at require (node:internal/modules/helpers:179:18)
    at Object.<anonymous> (/node_modules/.pnpm/svelte-preprocess-directives@0.1.1/node_modules/svelte-preprocess-directives/dist/index.js:9:25)
    at Module._compile (node:internal/modules/cjs/loader:1358:14)
```

This will patch will fix it